### PR TITLE
Isengard

### DIFF
--- a/resource.language.ro_ro/resources/langinfo.xml
+++ b/resource.language.ro_ro/resources/langinfo.xml
@@ -4,17 +4,17 @@
   <regions>
     <region name="România" locale="RO">
       <dateshort>DD.MM.YYYY</dateshort>
-      <datelong>DDDD, D MMMM YYYY</datelong>
-      <time symbolAM="" symbolPM="">H:mm:ss</time>
+      <datelong>D MMMM YYYY</datelong>
+      <time symbolAM="AM" symbolPM="PM">HH:mm xx</time>
       <tempunit>C</tempunit>
       <speedunit>kmh</speedunit>
       <timezone>EET</timezone>
     </region>
     
-    <region name="Rp. Moldova" locale="RO">
-	  <dateshort>DD.MM.YYYY</dateshort>
-      <datelong>DDDD, D MMMM YYYY</datelong>
-      <time symbolAM="" symbolPM="">H:mm:ss</time>
+    <region name="Republica Moldova" locale="RO">
+      <dateshort>DD.MM.YYYY</dateshort>
+      <datelong>D MMMM YYYY</datelong>
+      <time symbolAM="AM" symbolPM="PM">HH:mm xx</time>
       <tempunit>C</tempunit>
       <speedunit>kmh</speedunit>
       <timezone>EET</timezone>


### PR DESCRIPTION
Hi,

I've updated the romanian language add-on

I added the summary and description in romanian that can be seen in the add-on manager
For time I added the AM and PM symbols and xx to format to display them
Unfortunately I could not make the long date format to be displayed correctly

There seems to be a bug the that prevents Kodi from displaying the full name for day of week and month
http://trac.kodi.tv/ticket/15993

So, for now only 3 letters

Thank you

