### PR TITLE
Remove Genesis and PS controller

### DIFF
--- a/game.controller.genesis/addon.xml
+++ b/game.controller.genesis/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="game.controller.genesis"
         name="Genesis Controller"
-        version="1.0.5"
+        version="1.0.6"
         provider-name="Team Kodi">
     <requires>
     </requires>
@@ -10,5 +10,6 @@
         <summary lang="en_GB">Sega Genesis controller</summary>
         <description lang="en_GB">The original Sega Genesis controller had three main face buttons. Sega released a six-button version in 1993.</description>
         <platform>all</platform>
+        <broken>Controller profile is no longer available</broken>
     </extension>
 </addon>

--- a/game.controller.ps/addon.xml
+++ b/game.controller.ps/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="game.controller.ps"
         name="PlayStation Controller"
-        version="1.0.5"
+        version="1.0.6"
         provider-name="Team Kodi">
     <requires>
     </requires>
@@ -10,5 +10,6 @@
         <summary lang="en_GB">PlayStation controller</summary>
         <description lang="en_GB">The PlayStation Controller was released by Sony Computer Entertainment in 1994.</description>
         <platform>all</platform>
+        <broken>Controller profile is no longer available</broken>
     </extension>
 </addon>


### PR DESCRIPTION
IDs were changed in Leia, and we don't want these older controllers to show up.

Here is what is looks like in Leia now:

![screen shot 2018-09-29 at 2 25 15 pm](https://user-images.githubusercontent.com/531482/46255437-9c8e0080-c4a5-11e8-91cc-2840094c7dd1.png)
