### PR TITLE
[matrix] Add workflow to increment addon version

### DIFF
--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -1,0 +1,51 @@
+name: Increment version of updated languages
+
+on:
+  push:
+    branches: [ matrix, nexus ]
+    paths:
+      - '**resource.language.**strings.po'
+      - '**resource.language.**langinfo.xml'
+
+jobs:
+  default:
+    runs-on: ubuntu-latest
+    name: Increment version of updated languages
+
+    steps:
+
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: ${{ github.event.repository.name }}
+
+      - name: Checkout Scripts
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          repository: xbmc/weblate-supplementary-scripts
+          path: scripts
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Get changed files
+        uses: trilom/file-changes-action@v1.2.4
+
+      - name: Increment version of updated languages
+        run: |
+          python3 ../scripts/repo-resources/increment_version.py $HOME/files.json
+        working-directory: ${{ github.event.repository.name }}
+
+      - name: Create PR for incremented versions
+        uses: peter-evans/create-pull-request@v3.10.0
+        with:
+          commit-message: Language add-on versions incremented
+          title: Language add-on versions incremented
+          body: Language add-on versions incrementing triggered by ${{ github.sha }}
+          branch: inc-ver
+          delete-branch: true
+          path: ./${{ github.event.repository.name }}


### PR DESCRIPTION
### Description
This adds a workflow to bump the version in addon.xml for resource.language.* addons after a Weblate PR is merged.

Right now the workflow will create a pull request.
It can be changed to commit directly at a later time.

Please merge https://github.com/xbmc/repo-resources/pull/123 first.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-resources/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0