### PR TITLE
[matrix] Update en to en_GB in addon.xml

### DIFF
--- a/resource.language.af_za/addon.xml
+++ b/resource.language.af_za/addon.xml
@@ -21,8 +21,8 @@
     </dvd>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Afrikaans language pack</summary>
-    <description lang="en">Afrikaans version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Afrikaans language pack</summary>
+    <description lang="en_GB">Afrikaans version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.am_et/addon.xml
+++ b/resource.language.am_et/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Amharic language pack</summary>
-    <description lang="en">Amharic version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Amharic language pack</summary>
+    <description lang="en_GB">Amharic version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.ar_sa/addon.xml
+++ b/resource.language.ar_sa/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Arabic language pack</summary>
-    <description lang="en">Arabic version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Arabic language pack</summary>
+    <description lang="en_GB">Arabic version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.ast_es/addon.xml
+++ b/resource.language.ast_es/addon.xml
@@ -24,8 +24,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Asturian language pack</summary>
-    <description lang="en">Asturian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Asturian language pack</summary>
+    <description lang="en_GB">Asturian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.az_az/addon.xml
+++ b/resource.language.az_az/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Azerbaijani language pack</summary>
-    <description lang="en">Azerbaijani version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Azerbaijani language pack</summary>
+    <description lang="en_GB">Azerbaijani version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.be_by/addon.xml
+++ b/resource.language.be_by/addon.xml
@@ -36,8 +36,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Belarusian language pack</summary>
-    <description lang="en">Belarusian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Belarusian language pack</summary>
+    <description lang="en_GB">Belarusian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.bg_bg/addon.xml
+++ b/resource.language.bg_bg/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Bulgarian language pack</summary>
-    <description lang="en">Bulgarian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Bulgarian language pack</summary>
+    <description lang="en_GB">Bulgarian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.bs_ba/addon.xml
+++ b/resource.language.bs_ba/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Bosnian language pack</summary>
-    <description lang="en">Bosnian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Bosnian language pack</summary>
+    <description lang="en_GB">Bosnian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.ca_es/addon.xml
+++ b/resource.language.ca_es/addon.xml
@@ -28,8 +28,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Catalan language pack</summary>
-    <description lang="en">Catalan version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Catalan language pack</summary>
+    <description lang="en_GB">Catalan version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.cs_cz/addon.xml
+++ b/resource.language.cs_cz/addon.xml
@@ -19,8 +19,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Czech language pack</summary>
-    <description lang="en">Czech version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Czech language pack</summary>
+    <description lang="en_GB">Czech version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.cy_gb/addon.xml
+++ b/resource.language.cy_gb/addon.xml
@@ -19,8 +19,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Welsh language pack</summary>
-    <description lang="en">Welsh version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Welsh language pack</summary>
+    <description lang="en_GB">Welsh version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.da_dk/addon.xml
+++ b/resource.language.da_dk/addon.xml
@@ -19,8 +19,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Danish language pack</summary>
-    <description lang="en">Danish version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Danish language pack</summary>
+    <description lang="en_GB">Danish version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.de_de/addon.xml
+++ b/resource.language.de_de/addon.xml
@@ -22,8 +22,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">German language pack</summary>
-    <description lang="en">German version of all texts used in Kodi.</description>
+    <summary lang="en_GB">German language pack</summary>
+    <description lang="en_GB">German version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.el_gr/addon.xml
+++ b/resource.language.el_gr/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Greek language pack</summary>
-    <description lang="en">Greek version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Greek language pack</summary>
+    <description lang="en_GB">Greek version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.en_au/addon.xml
+++ b/resource.language.en_au/addon.xml
@@ -19,8 +19,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">English (Australia) language pack</summary>
-    <description lang="en">English (Australia) version of all texts used in Kodi.</description>
+    <summary lang="en_GB">English (Australia) language pack</summary>
+    <description lang="en_GB">English (Australia) version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.en_nz/addon.xml
+++ b/resource.language.en_nz/addon.xml
@@ -19,8 +19,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">English (New Zealand) language pack</summary>
-    <description lang="en">English (New Zealand) version of all texts used in Kodi.</description>
+    <summary lang="en_GB">English (New Zealand) language pack</summary>
+    <description lang="en_GB">English (New Zealand) version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.en_us/addon.xml
+++ b/resource.language.en_us/addon.xml
@@ -19,8 +19,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">English (US) language pack</summary>
-    <description lang="en">English (US) version of all texts used in Kodi.</description>
+    <summary lang="en_GB">English (US) language pack</summary>
+    <description lang="en_GB">English (US) version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.eo/addon.xml
+++ b/resource.language.eo/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Esperanto language pack</summary>
-    <description lang="en">Esperanto version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Esperanto language pack</summary>
+    <description lang="en_GB">Esperanto version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.es_ar/addon.xml
+++ b/resource.language.es_ar/addon.xml
@@ -24,8 +24,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Spanish (Argentina) language pack</summary>
-    <description lang="en">Spanish (Argentina) version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Spanish (Argentina) language pack</summary>
+    <description lang="en_GB">Spanish (Argentina) version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.es_es/addon.xml
+++ b/resource.language.es_es/addon.xml
@@ -24,8 +24,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Spanish language pack</summary>
-    <description lang="en">Spanish version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Spanish language pack</summary>
+    <description lang="en_GB">Spanish version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.es_mx/addon.xml
+++ b/resource.language.es_mx/addon.xml
@@ -26,8 +26,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Spanish (Mexico) language pack</summary>
-    <description lang="en">Spanish (Mexico) version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Spanish (Mexico) language pack</summary>
+    <description lang="en_GB">Spanish (Mexico) version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.et_ee/addon.xml
+++ b/resource.language.et_ee/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Estonian language pack</summary>
-    <description lang="en">Estonian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Estonian language pack</summary>
+    <description lang="en_GB">Estonian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.eu_es/addon.xml
+++ b/resource.language.eu_es/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Basque language pack</summary>
-    <description lang="en">Basque version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Basque language pack</summary>
+    <description lang="en_GB">Basque version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.fa_af/addon.xml
+++ b/resource.language.fa_af/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Persian language pack</summary>
-    <description lang="en">Persian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Persian language pack</summary>
+    <description lang="en_GB">Persian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.fa_ir/addon.xml
+++ b/resource.language.fa_ir/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Persian (Iran) language pack</summary>
-    <description lang="en">Persian (Iran) version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Persian (Iran) language pack</summary>
+    <description lang="en_GB">Persian (Iran) version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.fi_fi/addon.xml
+++ b/resource.language.fi_fi/addon.xml
@@ -19,8 +19,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Finnish language pack</summary>
-    <description lang="en">Finnish version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Finnish language pack</summary>
+    <description lang="en_GB">Finnish version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.fo_fo/addon.xml
+++ b/resource.language.fo_fo/addon.xml
@@ -19,8 +19,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Faroese language pack</summary>
-    <description lang="en">Faroese version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Faroese language pack</summary>
+    <description lang="en_GB">Faroese version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.fr_ca/addon.xml
+++ b/resource.language.fr_ca/addon.xml
@@ -23,8 +23,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">French (Canada) language pack</summary>
-    <description lang="en">French (Canada) version of all texts used in Kodi.</description>
+    <summary lang="en_GB">French (Canada) language pack</summary>
+    <description lang="en_GB">French (Canada) version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.fr_fr/addon.xml
+++ b/resource.language.fr_fr/addon.xml
@@ -23,8 +23,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">French language pack</summary>
-    <description lang="en">French version of all texts used in Kodi.</description>
+    <summary lang="en_GB">French language pack</summary>
+    <description lang="en_GB">French version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.gl_es/addon.xml
+++ b/resource.language.gl_es/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Galician language pack</summary>
-    <description lang="en">Galician version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Galician language pack</summary>
+    <description lang="en_GB">Galician version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.he_il/addon.xml
+++ b/resource.language.he_il/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Hebrew language pack</summary>
-    <description lang="en">Hebrew version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Hebrew language pack</summary>
+    <description lang="en_GB">Hebrew version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.hi_in/addon.xml
+++ b/resource.language.hi_in/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Hindi language pack</summary>
-    <description lang="en">Hindi version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Hindi language pack</summary>
+    <description lang="en_GB">Hindi version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.hr_hr/addon.xml
+++ b/resource.language.hr_hr/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Croatian language pack</summary>
-    <description lang="en">Croatian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Croatian language pack</summary>
+    <description lang="en_GB">Croatian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.hu_hu/addon.xml
+++ b/resource.language.hu_hu/addon.xml
@@ -21,8 +21,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Hungarian language pack</summary>
-    <description lang="en">Hungarian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Hungarian language pack</summary>
+    <description lang="en_GB">Hungarian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.hy_am/addon.xml
+++ b/resource.language.hy_am/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Armenian language pack</summary>
-    <description lang="en">Armenian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Armenian language pack</summary>
+    <description lang="en_GB">Armenian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.id_id/addon.xml
+++ b/resource.language.id_id/addon.xml
@@ -21,8 +21,8 @@
     </dvd>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Indonesian language pack</summary>
-    <description lang="en">Indonesian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Indonesian language pack</summary>
+    <description lang="en_GB">Indonesian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.is_is/addon.xml
+++ b/resource.language.is_is/addon.xml
@@ -19,8 +19,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Icelandic language pack</summary>
-    <description lang="en">Icelandic version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Icelandic language pack</summary>
+    <description lang="en_GB">Icelandic version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.it_it/addon.xml
+++ b/resource.language.it_it/addon.xml
@@ -29,8 +29,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Italian language pack</summary>
-    <description lang="en">Italian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Italian language pack</summary>
+    <description lang="en_GB">Italian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.ja_jp/addon.xml
+++ b/resource.language.ja_jp/addon.xml
@@ -19,8 +19,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Japanese language pack</summary>
-    <description lang="en">Japanese version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Japanese language pack</summary>
+    <description lang="en_GB">Japanese version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.kn_in/addon.xml
+++ b/resource.language.kn_in/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Kannada language pack</summary>
-    <description lang="en">Kannada version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Kannada language pack</summary>
+    <description lang="en_GB">Kannada version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.ko_kr/addon.xml
+++ b/resource.language.ko_kr/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Korean language pack</summary>
-    <description lang="en">Korean version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Korean language pack</summary>
+    <description lang="en_GB">Korean version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.lt_lt/addon.xml
+++ b/resource.language.lt_lt/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Lithuanian language pack</summary>
-    <description lang="en">Lithuanian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Lithuanian language pack</summary>
+    <description lang="en_GB">Lithuanian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.lv_lv/addon.xml
+++ b/resource.language.lv_lv/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Latvian language pack</summary>
-    <description lang="en">Latvian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Latvian language pack</summary>
+    <description lang="en_GB">Latvian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.mi/addon.xml
+++ b/resource.language.mi/addon.xml
@@ -24,8 +24,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Maori language pack</summary>
-    <description lang="en">Maori version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Maori language pack</summary>
+    <description lang="en_GB">Maori version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.mk_mk/addon.xml
+++ b/resource.language.mk_mk/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Macedonian language pack</summary>
-    <description lang="en">Macedonian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Macedonian language pack</summary>
+    <description lang="en_GB">Macedonian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.ml_in/addon.xml
+++ b/resource.language.ml_in/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Malayalam language pack</summary>
-    <description lang="en">Malayalam version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Malayalam language pack</summary>
+    <description lang="en_GB">Malayalam version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.mn_mn/addon.xml
+++ b/resource.language.mn_mn/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Mongolian language pack</summary>
-    <description lang="en">Mongolian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Mongolian language pack</summary>
+    <description lang="en_GB">Mongolian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.ms_my/addon.xml
+++ b/resource.language.ms_my/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Malay language pack</summary>
-    <description lang="en">Malay version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Malay language pack</summary>
+    <description lang="en_GB">Malay version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.mt_mt/addon.xml
+++ b/resource.language.mt_mt/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Maltese language pack</summary>
-    <description lang="en">Maltese version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Maltese language pack</summary>
+    <description lang="en_GB">Maltese version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.my_mm/addon.xml
+++ b/resource.language.my_mm/addon.xml
@@ -19,8 +19,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Burmese language pack</summary>
-    <description lang="en">Burmese version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Burmese language pack</summary>
+    <description lang="en_GB">Burmese version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.nb_no/addon.xml
+++ b/resource.language.nb_no/addon.xml
@@ -19,8 +19,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Norwegian language pack</summary>
-    <description lang="en">Norwegian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Norwegian language pack</summary>
+    <description lang="en_GB">Norwegian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.nl_nl/addon.xml
+++ b/resource.language.nl_nl/addon.xml
@@ -22,8 +22,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Dutch language pack</summary>
-    <description lang="en">Dutch version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Dutch language pack</summary>
+    <description lang="en_GB">Dutch version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.os_os/addon.xml
+++ b/resource.language.os_os/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Ossetic language pack</summary>
-    <description lang="en">Ossetic version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Ossetic language pack</summary>
+    <description lang="en_GB">Ossetic version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.pl_pl/addon.xml
+++ b/resource.language.pl_pl/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Polish language pack</summary>
-    <description lang="en">Polish version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Polish language pack</summary>
+    <description lang="en_GB">Polish version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.pt_br/addon.xml
+++ b/resource.language.pt_br/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Portuguese (Brazil) language pack</summary>
-    <description lang="en">Portuguese (Brazil) version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Portuguese (Brazil) language pack</summary>
+    <description lang="en_GB">Portuguese (Brazil) version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.pt_pt/addon.xml
+++ b/resource.language.pt_pt/addon.xml
@@ -23,8 +23,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Portuguese language pack</summary>
-    <description lang="en">Portuguese version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Portuguese language pack</summary>
+    <description lang="en_GB">Portuguese version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.ro_ro/addon.xml
+++ b/resource.language.ro_ro/addon.xml
@@ -19,8 +19,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Romanian language pack</summary>
-    <description lang="en">Romanian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Romanian language pack</summary>
+    <description lang="en_GB">Romanian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.ru_ru/addon.xml
+++ b/resource.language.ru_ru/addon.xml
@@ -36,8 +36,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Russian language pack</summary>
-    <description lang="en">Russian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Russian language pack</summary>
+    <description lang="en_GB">Russian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.si_lk/addon.xml
+++ b/resource.language.si_lk/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Sinhala language pack</summary>
-    <description lang="en">Sinhala version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Sinhala language pack</summary>
+    <description lang="en_GB">Sinhala version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.sk_sk/addon.xml
+++ b/resource.language.sk_sk/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Slovak language pack</summary>
-    <description lang="en">Slovak version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Slovak language pack</summary>
+    <description lang="en_GB">Slovak version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.sl_si/addon.xml
+++ b/resource.language.sl_si/addon.xml
@@ -22,8 +22,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Slovenian language pack</summary>
-    <description lang="en">Slovenian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Slovenian language pack</summary>
+    <description lang="en_GB">Slovenian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.sq_al/addon.xml
+++ b/resource.language.sq_al/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Albanian language pack</summary>
-    <description lang="en">Albanian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Albanian language pack</summary>
+    <description lang="en_GB">Albanian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.sr_rs/addon.xml
+++ b/resource.language.sr_rs/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Serbian (Cyrillic) language pack</summary>
-    <description lang="en">Serbian (Cyrillic) version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Serbian (Cyrillic) language pack</summary>
+    <description lang="en_GB">Serbian (Cyrillic) version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.sr_rs@latin/addon.xml
+++ b/resource.language.sr_rs@latin/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Serbian language pack</summary>
-    <description lang="en">Serbian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Serbian language pack</summary>
+    <description lang="en_GB">Serbian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.sv_se/addon.xml
+++ b/resource.language.sv_se/addon.xml
@@ -19,8 +19,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Swedish language pack</summary>
-    <description lang="en">Swedish version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Swedish language pack</summary>
+    <description lang="en_GB">Swedish version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.szl/addon.xml
+++ b/resource.language.szl/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Silesian language pack</summary>
-    <description lang="en">Silesian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Silesian language pack</summary>
+    <description lang="en_GB">Silesian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.ta_in/addon.xml
+++ b/resource.language.ta_in/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Tamil (India) language pack</summary>
-    <description lang="en">Tamil (India) version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Tamil (India) language pack</summary>
+    <description lang="en_GB">Tamil (India) version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.te_in/addon.xml
+++ b/resource.language.te_in/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Telugu language pack</summary>
-    <description lang="en">Telugu version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Telugu language pack</summary>
+    <description lang="en_GB">Telugu version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.tg_tj/addon.xml
+++ b/resource.language.tg_tj/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Tajik language pack</summary>
-    <description lang="en">Tajik version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Tajik language pack</summary>
+    <description lang="en_GB">Tajik version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.th_th/addon.xml
+++ b/resource.language.th_th/addon.xml
@@ -19,8 +19,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Thai language pack</summary>
-    <description lang="en">Thai version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Thai language pack</summary>
+    <description lang="en_GB">Thai version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.tr_tr/addon.xml
+++ b/resource.language.tr_tr/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Turkish language pack</summary>
-    <description lang="en">Turkish version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Turkish language pack</summary>
+    <description lang="en_GB">Turkish version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.uk_ua/addon.xml
+++ b/resource.language.uk_ua/addon.xml
@@ -36,8 +36,8 @@
     </sorttokens>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Ukrainian language pack</summary>
-    <description lang="en">Ukrainian version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Ukrainian language pack</summary>
+    <description lang="en_GB">Ukrainian version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.uz_uz/addon.xml
+++ b/resource.language.uz_uz/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Uzbek language pack</summary>
-    <description lang="en">Uzbek version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Uzbek language pack</summary>
+    <description lang="en_GB">Uzbek version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.vi_vn/addon.xml
+++ b/resource.language.vi_vn/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Vietnamese language pack</summary>
-    <description lang="en">Vietnamese version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Vietnamese language pack</summary>
+    <description lang="en_GB">Vietnamese version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.zh_cn/addon.xml
+++ b/resource.language.zh_cn/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Chinese (Simple) language pack</summary>
-    <description lang="en">Chinese (Simple) version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Chinese (Simple) language pack</summary>
+    <description lang="en_GB">Chinese (Simple) version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>

--- a/resource.language.zh_tw/addon.xml
+++ b/resource.language.zh_tw/addon.xml
@@ -16,8 +16,8 @@
     </charsets>
   </extension>
   <extension point="kodi.addon.metadata">
-    <summary lang="en">Chinese (Traditional) language pack</summary>
-    <description lang="en">Chinese (Traditional) version of all texts used in Kodi.</description>
+    <summary lang="en_GB">Chinese (Traditional) language pack</summary>
+    <description lang="en_GB">Chinese (Traditional) version of all texts used in Kodi.</description>
     <platform>all</platform>
     <assets>
       <icon>icon.png</icon>


### PR DESCRIPTION
### Description
This updates `description` and `summary` in addon.xml to use `en_GB` instead of deprecated `en` language code.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-resources/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0