### PR TITLE
[matrix] update increment-version.yml to only run for matrix branch

### DIFF
--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -2,7 +2,7 @@ name: Increment version of updated languages
 
 on:
   push:
-    branches: [ matrix, nexus ]
+    branches: [ matrix ]
     paths:
       - '**resource.language.**strings.po'
       - '**resource.language.**langinfo.xml'


### PR DESCRIPTION
### Description
Now that we have a seperate workflow for nexus branch, this workflow should only work for matrix branch.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-resources/blob/master/CONTRIBUTING.md) document