### PR TITLE
[nexus] Bump version of language addons

### DIFF
--- a/resource.language.af_za/addon.xml
+++ b/resource.language.af_za/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.af_za"
-  version="9.0.34"
+  version="9.0.35"
   name="Afrikaans"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.am_et/addon.xml
+++ b/resource.language.am_et/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.am_et"
-  version="9.0.31"
+  version="9.0.32"
   name="Amharic"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.ar_sa/addon.xml
+++ b/resource.language.ar_sa/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.ar_sa"
-  version="9.0.33"
+  version="9.0.34"
   name="Arabic"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.ast_es/addon.xml
+++ b/resource.language.ast_es/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.ast_es"
-  version="1.0.22"
+  version="1.0.23"
   name="Asturian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.az_az/addon.xml
+++ b/resource.language.az_az/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.az_az"
-  version="9.0.25"
+  version="9.0.26"
   name="Azerbaijani"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.be_by/addon.xml
+++ b/resource.language.be_by/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.be_by"
-  version="9.0.39"
+  version="9.0.40"
   name="Belarusian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.bg_bg/addon.xml
+++ b/resource.language.bg_bg/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.bg_bg"
-  version="9.0.52"
+  version="9.0.53"
   name="Bulgarian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.bs_ba/addon.xml
+++ b/resource.language.bs_ba/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.bs_ba"
-  version="9.0.27"
+  version="9.0.28"
   name="Bosnian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.ca_es/addon.xml
+++ b/resource.language.ca_es/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.ca_es"
-  version="9.0.34"
+  version="9.0.35"
   name="Catalan"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.cs_cz/addon.xml
+++ b/resource.language.cs_cz/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.cs_cz"
-  version="9.0.54"
+  version="9.0.55"
   name="Czech"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.cy_gb/addon.xml
+++ b/resource.language.cy_gb/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.cy_gb"
-  version="9.0.33"
+  version="9.0.34"
   name="Welsh"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.da_dk/addon.xml
+++ b/resource.language.da_dk/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.da_dk"
-  version="9.0.57"
+  version="9.0.58"
   name="Danish"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.de_de/addon.xml
+++ b/resource.language.de_de/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.de_de"
-  version="9.0.57"
+  version="9.0.58"
   name="German"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.el_gr/addon.xml
+++ b/resource.language.el_gr/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.el_gr"
-  version="9.0.41"
+  version="9.0.42"
   name="Greek"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.en_au/addon.xml
+++ b/resource.language.en_au/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.en_au"
-  version="9.0.29"
+  version="9.0.30"
   name="English (Australia)"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.en_nz/addon.xml
+++ b/resource.language.en_nz/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.en_nz"
-  version="9.0.32"
+  version="9.0.33"
   name="English (New Zealand)"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.en_us/addon.xml
+++ b/resource.language.en_us/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.en_us"
-  version="9.0.41"
+  version="9.0.42"
   name="English (US)"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.eo/addon.xml
+++ b/resource.language.eo/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.eo"
-  version="9.0.27"
+  version="9.0.28"
   name="Esperanto"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.es_ar/addon.xml
+++ b/resource.language.es_ar/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.es_ar"
-  version="9.0.31"
+  version="9.0.32"
   name="Spanish (Argentina)"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.es_es/addon.xml
+++ b/resource.language.es_es/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.es_es"
-  version="9.0.53"
+  version="9.0.54"
   name="Spanish"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.es_mx/addon.xml
+++ b/resource.language.es_mx/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.es_mx"
-  version="9.0.40"
+  version="9.0.41"
   name="Spanish (Mexico)"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.et_ee/addon.xml
+++ b/resource.language.et_ee/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.et_ee"
-  version="9.0.45"
+  version="9.0.46"
   name="Estonian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.eu_es/addon.xml
+++ b/resource.language.eu_es/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.eu_es"
-  version="9.0.38"
+  version="9.0.39"
   name="Basque"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.fa_af/addon.xml
+++ b/resource.language.fa_af/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.fa_af"
-  version="9.0.27"
+  version="9.0.28"
   name="Persian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.fa_ir/addon.xml
+++ b/resource.language.fa_ir/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.fa_ir"
-  version="9.0.34"
+  version="9.0.35"
   name="Persian (Iran)"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.fi_fi/addon.xml
+++ b/resource.language.fi_fi/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.fi_fi"
-  version="9.0.59"
+  version="9.0.60"
   name="Finnish"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.fil/addon.xml
+++ b/resource.language.fil/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.fil"
-  version="1.0.0"
+  version="1.0.1"
   name="Filipino (Talagog)"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.fo_fo/addon.xml
+++ b/resource.language.fo_fo/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.fo_fo"
-  version="9.0.28"
+  version="9.0.29"
   name="Faroese"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.fr_ca/addon.xml
+++ b/resource.language.fr_ca/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.fr_ca"
-  version="9.0.48"
+  version="9.0.49"
   name="French (Canada)"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.fr_fr/addon.xml
+++ b/resource.language.fr_fr/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.fr_fr"
-  version="9.0.61"
+  version="9.0.62"
   name="French"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.gl_es/addon.xml
+++ b/resource.language.gl_es/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.gl_es"
-  version="9.0.38"
+  version="9.0.39"
   name="Galician"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.he_il/addon.xml
+++ b/resource.language.he_il/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.he_il"
-  version="9.0.38"
+  version="9.0.39"
   name="Hebrew"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.hi_in/addon.xml
+++ b/resource.language.hi_in/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.hi_in"
-  version="9.0.25"
+  version="9.0.26"
   name="Hindi (Devanagiri)"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.hr_hr/addon.xml
+++ b/resource.language.hr_hr/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.hr_hr"
-  version="9.0.41"
+  version="9.0.42"
   name="Croatian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.hu_hu/addon.xml
+++ b/resource.language.hu_hu/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.hu_hu"
-  version="9.0.49"
+  version="9.0.50"
   name="Hungarian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.hy_am/addon.xml
+++ b/resource.language.hy_am/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.hy_am"
-  version="9.0.26"
+  version="9.0.27"
   name="Armenian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.id_id/addon.xml
+++ b/resource.language.id_id/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.id_id"
-  version="9.0.36"
+  version="9.0.37"
   name="Indonesian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.is_is/addon.xml
+++ b/resource.language.is_is/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.is_is"
-  version="9.0.41"
+  version="9.0.42"
   name="Icelandic"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.it_it/addon.xml
+++ b/resource.language.it_it/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.it_it"
-  version="9.0.50"
+  version="9.0.51"
   name="Italian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.ja_jp/addon.xml
+++ b/resource.language.ja_jp/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.ja_jp"
-  version="9.0.41"
+  version="9.0.42"
   name="Japanese"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.kn_in/addon.xml
+++ b/resource.language.kn_in/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.kn_in"
-  version="1.0.21"
+  version="1.0.22"
   name="Kannada"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.ko_kr/addon.xml
+++ b/resource.language.ko_kr/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.ko_kr"
-  version="9.0.48"
+  version="9.0.49"
   name="Korean"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.lt_lt/addon.xml
+++ b/resource.language.lt_lt/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.lt_lt"
-  version="9.0.50"
+  version="9.0.51"
   name="Lithuanian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.lv_lv/addon.xml
+++ b/resource.language.lv_lv/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.lv_lv"
-  version="9.0.37"
+  version="9.0.38"
   name="Latvian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.mi/addon.xml
+++ b/resource.language.mi/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.mi"
-  version="9.0.28"
+  version="9.0.29"
   name="Maori"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.mk_mk/addon.xml
+++ b/resource.language.mk_mk/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.mk_mk"
-  version="9.0.31"
+  version="9.0.32"
   name="Macedonian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.ml_in/addon.xml
+++ b/resource.language.ml_in/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.ml_in"
-  version="9.0.21"
+  version="9.0.22"
   name="Malayalam"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.mn_mn/addon.xml
+++ b/resource.language.mn_mn/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.mn_mn"
-  version="9.0.26"
+  version="9.0.27"
   name="Mongolian (Mongolia)"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.ms_my/addon.xml
+++ b/resource.language.ms_my/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.ms_my"
-  version="9.0.37"
+  version="9.0.38"
   name="Malay"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.mt_mt/addon.xml
+++ b/resource.language.mt_mt/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.mt_mt"
-  version="9.0.30"
+  version="9.0.31"
   name="Maltese"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.my_mm/addon.xml
+++ b/resource.language.my_mm/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.my_mm"
-  version="9.0.28"
+  version="9.0.29"
   name="Burmese"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.nb_no/addon.xml
+++ b/resource.language.nb_no/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.nb_no"
-  version="9.0.37"
+  version="9.0.38"
   name="Norwegian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.nl_nl/addon.xml
+++ b/resource.language.nl_nl/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.nl_nl"
-  version="9.0.49"
+  version="9.0.50"
   name="Dutch"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.os_os/addon.xml
+++ b/resource.language.os_os/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.os_os"
-  version="1.0.22"
+  version="1.0.23"
   name="Ossetic"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.pl_pl/addon.xml
+++ b/resource.language.pl_pl/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.pl_pl"
-  version="9.0.43"
+  version="9.0.44"
   name="Polish"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.pt_br/addon.xml
+++ b/resource.language.pt_br/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.pt_br"
-  version="9.0.57"
+  version="9.0.58"
   name="Portuguese (Brazil)"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.pt_pt/addon.xml
+++ b/resource.language.pt_pt/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.pt_pt"
-  version="9.0.37"
+  version="9.0.38"
   name="Portuguese"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.ro_ro/addon.xml
+++ b/resource.language.ro_ro/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.ro_ro"
-  version="9.0.40"
+  version="9.0.41"
   name="Romanian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.ru_ru/addon.xml
+++ b/resource.language.ru_ru/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.ru_ru"
-  version="9.0.50"
+  version="9.0.51"
   name="Russian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.si_lk/addon.xml
+++ b/resource.language.si_lk/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.si_lk"
-  version="9.0.27"
+  version="9.0.28"
   name="Sinhala"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.sk_sk/addon.xml
+++ b/resource.language.sk_sk/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.sk_sk"
-  version="9.0.49"
+  version="9.0.50"
   name="Slovak"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.sl_si/addon.xml
+++ b/resource.language.sl_si/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.sl_si"
-  version="9.0.34"
+  version="9.0.35"
   name="Slovenian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.sq_al/addon.xml
+++ b/resource.language.sq_al/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.sq_al"
-  version="9.0.29"
+  version="9.0.30"
   name="Albanian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.sr_rs/addon.xml
+++ b/resource.language.sr_rs/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.sr_rs"
-  version="9.0.38"
+  version="9.0.39"
   name="Serbian (Cyrillic)"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.sr_rs@latin/addon.xml
+++ b/resource.language.sr_rs@latin/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.sr_rs@latin"
-  version="9.0.30"
+  version="9.0.31"
   name="Serbian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.sv_se/addon.xml
+++ b/resource.language.sv_se/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.sv_se"
-  version="9.0.52"
+  version="9.0.53"
   name="Swedish"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.szl/addon.xml
+++ b/resource.language.szl/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.szl"
-  version="9.0.31"
+  version="9.0.32"
   name="Silesian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.ta_in/addon.xml
+++ b/resource.language.ta_in/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.ta_in"
-  version="9.0.31"
+  version="9.0.32"
   name="Tamil (India)"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.te_in/addon.xml
+++ b/resource.language.te_in/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.te_in"
-  version="9.0.22"
+  version="9.0.23"
   name="Telugu"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.tg_tj/addon.xml
+++ b/resource.language.tg_tj/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.tg_tj"
-  version="9.0.28"
+  version="9.0.29"
   name="Tajik"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.th_th/addon.xml
+++ b/resource.language.th_th/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.th_th"
-  version="9.0.32"
+  version="9.0.33"
   name="Thai"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.tr_tr/addon.xml
+++ b/resource.language.tr_tr/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.tr_tr"
-  version="9.0.48"
+  version="9.0.49"
   name="Turkish"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.uk_ua/addon.xml
+++ b/resource.language.uk_ua/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.uk_ua"
-  version="9.0.36"
+  version="9.0.37"
   name="Ukrainian"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.uz_uz/addon.xml
+++ b/resource.language.uz_uz/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.uz_uz"
-  version="9.0.26"
+  version="9.0.27"
   name="Uzbek"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.vi_vn/addon.xml
+++ b/resource.language.vi_vn/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.vi_vn"
-  version="9.0.37"
+  version="9.0.38"
   name="Vietnamese"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.zh_cn/addon.xml
+++ b/resource.language.zh_cn/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.zh_cn"
-  version="9.0.48"
+  version="9.0.49"
   name="Chinese (Simple)"
   provider-name="Team Kodi">
   <requires>

--- a/resource.language.zh_tw/addon.xml
+++ b/resource.language.zh_tw/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.zh_tw"
-  version="9.0.53"
+  version="9.0.54"
   name="Chinese (Traditional)"
   provider-name="Team Kodi">
   <requires>


### PR DESCRIPTION
### Description
This will bump version numbers of all language addons
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-resources/blob/master/CONTRIBUTING.md) document
- [ ] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0