### PR TITLE
Add addon-checker to nexus PRs

### DIFF
--- a/.github/workflows/addon-checker.yml
+++ b/.github/workflows/addon-checker.yml
@@ -1,0 +1,32 @@
+name: Kodi Addon-Checker
+
+on: [pull_request]
+
+jobs:
+  kodi-addon-checker:
+    runs-on: ubuntu-latest
+    name: Kodi Addon-Checker
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip3 install --user kodi-addon-checker
+    - name: Extract job variables
+      shell: bash
+      run: echo "##[set-output name=addon;]$(git diff --diff-filter=d --name-only HEAD~ | grep / | cut -d / -f1 | sort | uniq)"
+      id: extract_vars
+
+    - name: Addon-Check
+      run: $HOME/.local/bin/kodi-addon-checker --branch=${{ github.event.pull_request.base.ref }} --PR ${{ steps.extract_vars.outputs.addon }}
+


### PR DESCRIPTION
### Description
CI to check repo-resources PRs against nexus branch was missing

REF: https://github.com/xbmc/repo-resources/pull/352