### PR TITLE
Update addon.xml

### DIFF
--- a/resource.language.ga_ie/addon.xml
+++ b/resource.language.ga_ie/addon.xml
@@ -9,7 +9,7 @@
   </requires>
   <extension
     point="kodi.resource.language"
-    locale="ie_GA">
+    locale="ga_IE">
     <charsets>
       <gui>CP1252</gui>
       <subtitle>CP1252</subtitle>


### PR DESCRIPTION
changed extension locale to from ie_GA to ga_IE

### Description
Relates to language pack not being loaded - I spotted a mistake with the locale, it was ie_GA instead of ga_IE, this may  fix the issue of language pack not loading.

- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-resources/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
