### PR TITLE
game.controller.dreamcast: Fix Dreamcast analog triggers

### DIFF
--- a/game.controller.dreamcast/addon.xml
+++ b/game.controller.dreamcast/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="game.controller.dreamcast"
         name="Dreamcast Controller"
-        version="1.0.35"
+        version="1.0.36"
         provider-name="Team Kodi">
     <extension point="kodi.game.controller" library="resources/layout.xml"/>
     <extension point="xbmc.addon.metadata">

--- a/game.controller.dreamcast/resources/layout.xml
+++ b/game.controller.dreamcast/resources/layout.xml
@@ -12,8 +12,8 @@
 		<button name="left" type="digital" label="30009"/>
 	</category>
 	<category name="triggers" label="35076">
-		<button name="lefttrigger" type="digital" label="30010"/>
-		<button name="righttrigger" type="digital" label="30011"/>
+		<button name="lefttrigger" type="analog" label="30010"/>
+		<button name="righttrigger" type="analog" label="30011"/>
 	</category>
 	<category name="analogsticks" label="35077">
 		<analogstick name="analogstick" label="30012"/>


### PR DESCRIPTION
### Description

Updates to version v1.0.36.

Changes since v1.0.35:

  * Fixed Dreamcast analog triggers (https://github.com/kodi-game/controller-topology-project/pull/467)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-resources/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
